### PR TITLE
Fix mobile layout: nav overlap and weather stat wrapping

### DIFF
--- a/src/components/WeatherStat.jsx
+++ b/src/components/WeatherStat.jsx
@@ -4,7 +4,7 @@ const WeatherStat = ({ label, value, meets, threshold }) => (
   <div className="text-center flex flex-col items-center gap-1">
     <p className="text-xs font-semibold uppercase tracking-widest text-gray-400">{label}</p>
     <div className="flex items-center gap-1.5">
-      <p className="text-2xl font-bold text-gray-800">{value}</p>
+      <p className="text-lg sm:text-2xl font-bold text-gray-800 whitespace-nowrap">{value}</p>
       {meets ? (
         <Check className="h-5 w-5 text-green-500 flex-shrink-0" />
       ) : (

--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -91,15 +91,15 @@ const Index = () => {
   }
 
   return (
-    <div className={`relative min-h-screen transition-colors duration-700 ${isGood ? 'bg-gradient-to-br from-amber-50 via-yellow-50 to-amber-100' : 'bg-gradient-to-br from-slate-100 via-gray-100 to-slate-200'}`}>
+    <div className={`min-h-screen flex flex-col transition-colors duration-700 ${isGood ? 'bg-gradient-to-br from-amber-50 via-yellow-50 to-amber-100' : 'bg-gradient-to-br from-slate-100 via-gray-100 to-slate-200'}`}>
 
       {/* Top-right nav */}
-      <nav className="absolute top-4 right-5 flex gap-5 text-sm font-medium text-gray-500">
+      <nav className="flex justify-end px-5 pt-4 gap-5 text-sm font-medium text-gray-500">
         <Link to="/about" className="hover:text-gray-800 transition-colors">Why though?</Link>
         <Link to="/history" className="hover:text-gray-800 transition-colors">The record</Link>
       </nav>
 
-      <div className="flex flex-col items-center justify-center min-h-screen px-6 py-6">
+      <div className="flex flex-col items-center justify-center flex-1 px-6 py-6">
 
         {/* Season badge */}
         <span className={`text-xs font-bold uppercase tracking-widest px-3 py-1.5 rounded-full mb-6 ${isShitsville ? 'bg-slate-700 text-slate-100' : 'bg-amber-200 text-amber-800'}`}>
@@ -122,7 +122,7 @@ const Index = () => {
         </p>
 
         {/* Weather stats */}
-        <div className="grid grid-cols-3 gap-6 sm:gap-10 mb-6">
+        <div className="grid grid-cols-3 gap-3 sm:gap-10 mb-6">
           <WeatherStat
             label="Temperature"
             value={`${weather.temperature.toFixed(1)}°C`}


### PR DESCRIPTION
Nav was absolutely positioned and overlapped the season badge on narrow screens.
Moved it into the flex flow (justify-end) so it stacks above the content area.

Weather stat values like "33.5 km/h" were wrapping onto two lines inside the
3-column grid on mobile; reduced font to text-lg on small screens (sm:text-2xl
on desktop), added whitespace-nowrap, and tightened the column gap to gap-3 on
mobile (sm:gap-10 on desktop).

https://claude.ai/code/session_01HKAiZH7oMRgkeCkAEW3ko5